### PR TITLE
Active admin Renamed from Admins => Admin

### DIFF
--- a/lib/active_admin/async_export/async_export_mailer.rb
+++ b/lib/active_admin/async_export/async_export_mailer.rb
@@ -3,12 +3,12 @@ module ActiveAdmin
     class AsyncExportMailer < ActionMailer::Base
       add_template_helper MethodOrProcHelper
 
-      def csv_export(admin_email, model_name)
-        controller = Kernel::qualified_const_get("Admins::#{model_name}sController").new
+      def csv_export(admin_email, model_name , collection)
+        controller = Kernel::qualified_const_get("Admin::#{model_name}sController").new
         config = controller.send(:active_admin_config)
         path = controller.send(:active_admin_template, 'index.csv')
         csv_filename = controller.send(:csv_filename)
-        collection = controller.send(:scoped_collection)
+        
         app = ActiveAdmin.application
 
         csv = render_to_string(file: path,

--- a/lib/active_admin/async_export/resource_controller_extension.rb
+++ b/lib/active_admin/async_export/resource_controller_extension.rb
@@ -11,11 +11,23 @@ module ActiveAdmin
           format.email do
             current_user_method = active_admin_config.namespace.application.current_user_method
             admin_email = send(current_user_method).email
-            ActiveAdmin::AsyncExport::AsyncExportMailer.delay.csv_export(admin_email, collection.first.class.to_s)
+
+            ActiveAdmin::AsyncExport::AsyncExportMailer.delay.csv_export(admin_email, collection.first.class.to_s, csv_collection)
             redirect_to :back, notice: "CSV export emailed to #{admin_email}!"
           end
         end
       end
+
+      def csv_collection
+        collection = scoped_collection
+
+        collection = apply_authorization_scope(collection)
+        collection = apply_sorting(collection)
+        collection = apply_filtering(collection)
+        collection = apply_scoping(collection)
+        collection.to_a
+      end
+
     end
   end
 end


### PR DESCRIPTION
scoped_collection only returns ActiveRecord::Relation object (IE: User) , this needs to be scoped to our collection.  Adds new collection var to the index_with_email action to pass to the CSV export

There could be a better way to access the scoped_collection, however the only way i saw to turn off pagination for an action was to pass in the option :paginate => false. 
